### PR TITLE
Set org.apache.sshd.sshd-sftp to 2.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.apache.sshd</groupId>
             <artifactId>sshd-sftp</artifactId>
-            <version>[2,)</version>
+            <version>[2.5.1)</version>
         </dependency>
         <dependency>
             <groupId>com.github.stefanbirkner</groupId>


### PR DESCRIPTION
Current code is not compatible with the new 2.6.0 version of org.apache.sshd.sshd-sftp:

`java.lang.NoClassDefFoundError: org/apache/sshd/server/subsystem/sftp/SftpSubsystemFactory`

Set org.apache.sshd.sshd-sftp to 2.5.1.