### PR TITLE
Add CloseableFakeSftpServer extends FakeSftpServer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,12 @@
+# Eclipse
+.settings/
+.classpath
+.project
+
+# IntelliJ IDEA
+.idea/
+*.iml
+
+# Maven
+target/
 .flattened-pom.xml
-target

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>fake-sftp-server-lambda</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Fake SFTP Server Lambda</name>

--- a/src/main/java/com/github/stefanbirkner/fakesftpserver/lambda/CloseableFakeSftpServer.java
+++ b/src/main/java/com/github/stefanbirkner/fakesftpserver/lambda/CloseableFakeSftpServer.java
@@ -1,0 +1,56 @@
+package com.github.stefanbirkner.fakesftpserver.lambda;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.nio.file.FileSystem;
+
+/**
+ * This extension of {@link FakeSftpServer} can be instantiated, configured and closed manually,
+ * if doing everything within a single lambda expression is undesirable for your use case.
+ * <p>For example, in BDD (behaviour-driven development) you want to test in a <i>given-when-then</i>
+ * fashion, i.e. separate the stimulus to the system under test (when) from verifying results later
+ * (then). Some test frameworks like Spock even require separate blocks, making the use of a single
+ * lambda feel somewhat unnatural and clunky there.
+ * <p>Because this class implements {@link AutoCloseable}, if you like you can instantiate it in a
+ * <i>try with resources</i> structure.
+ * <p>A parametrised Spock (Groovy) example test looks like this:
+ * <pre>
+ * class MySFTPServerTest extends Specification {
+ *   &#064;AutoCleanup
+ *   def server = new CloseableFakeSftpServer()
+ *
+ *   &#064;Unroll("user #user downloads file #file")
+ *   def "users can download text files"() {
+ *     given: "a preconfigured fake SFTP server"
+ *     server.addUser(user, password)
+ *     server.putFile(file, content, UTF_8)
+ *
+ *     and: "an SFTP client under test"
+ *     def client = new SFTPFileDownloader("localhost", server.port, user, password)
+ *
+ *     expect:
+ *     client.getFileContent(file) == content
+ *
+ *     where:
+ *     user    | password | file                   | content
+ *     "me"    | "xoxox"  | "/a/b/c/one.txt"       | "First line\nSecondLine\n"
+ *     "you"   | "mypass" | "/etc/two.xml"         | "<root><foo>abc</foo></root>"
+ *     "admin" | "secret" | "/home/admin/three.sh" | "#!/usr/bin/bash\n\nls -al\n"
+ *   }
+ * }
+ * </pre>
+ */
+public class CloseableFakeSftpServer extends FakeSftpServer implements AutoCloseable {
+    protected final Closeable closeServer;
+
+    public CloseableFakeSftpServer() throws IOException {
+        super(FakeSftpServer.createFileSystem());
+        closeServer = start(0);
+    }
+
+    @Override
+    public void close() throws Exception {
+        fileSystem.close();
+        closeServer.close();
+    }
+}

--- a/src/main/java/com/github/stefanbirkner/fakesftpserver/lambda/FakeSftpServer.java
+++ b/src/main/java/com/github/stefanbirkner/fakesftpserver/lambda/FakeSftpServer.java
@@ -214,18 +214,19 @@ public class FakeSftpServer {
             }
     };
     private static final Random RANDOM = new Random();
-    private final FileSystem fileSystem;
+    protected final FileSystem fileSystem;
     private SshServer server;
     private boolean withSftpServerFinished = false;
     private final Map<String, String> usernamesAndPasswords = new HashMap<>();
 
     /**
-     * {@code FakeSftpServer} cannot be created manually. It is always provided
+     * {@code FakeSftpServer} should not be created manually (unless by
+     * subclasses which know what they are doing). It is always provided
      * to an {@link ExceptionThrowingConsumer}
      * by {@link #withSftpServer(ExceptionThrowingConsumer)}.
      * @param fileSystem the file system that is used for storing the files
      */
-    private FakeSftpServer(
+    protected FakeSftpServer(
         FileSystem fileSystem
     ) {
         this.fileSystem = fileSystem;
@@ -423,12 +424,12 @@ public class FakeSftpServer {
             walkFileTree(directory, DELETE_FILES_AND_DIRECTORIES);
     }
 
-    private static FileSystem createFileSystem(
+    protected static FileSystem createFileSystem(
     ) throws IOException {
         return newLinux().build("FakeSftpServer-" + RANDOM.nextInt());
     }
 
-    private Closeable start(
+    protected Closeable start(
         int port
     ) throws IOException {
         SshServer server = SshServer.setUpDefaultServer();


### PR DESCRIPTION
The class can be instantiated, configured and closed manually, if doing everything within a single lambda expression is undesirable for a given use case. In order to achieve that, some methods and fields had to be made `protected` (from `final`).

For example, in BDD (behaviour-driven development) users want to test in a given-when-then fashion, i.e. separate the stimulus to the system under test (when) from verifying results later (then). Some test frameworks like [Spock](https://spockframework.org/) even require separate blocks, making the use of a single lambda feel somewhat unnatural and clunky there. See also [this Stack Overflow answer](https://stackoverflow.com/a/71085561/1082681).

Because the class implements `AutoCloseable`, it can be optionally also be instantiated in a try with resources structure.

A parametrised Spock (Groovy) example test looks like this:

```groovy
class MySFTPServerTest extends Specification {
  @AutoCleanup
  def server = new CloseableFakeSftpServer()

  @Unroll("user #user downloads file #file")
  def "users can download text files"() {
    given: "a preconfigured fake SFTP server"
    server.addUser(user, password)
    server.putFile(file, content, UTF_8)

    and: "an SFTP client under test"
    def client = new SFTPFileDownloader("localhost", server.port, user, password)

    expect:
    client.getFileContent(file) == content

    where:
    user    | password | file                   | content
    "me"    | "xoxox"  | "/a/b/c/one.txt"       | "First line\nSecondLine\n"
    "you"   | "mypass" | "/etc/two.xml"         | "<root><foo>abc</foo></root>"
    "admin" | "secret" | "/home/admin/three.sh" | "#!/usr/bin/bash\n\nls -al\n"
  }
}
```

With the original `FakeSftpServer`, everything that is now cleanly separated by concern in the `given:`, `and:`, `expect:` blocks would be done within a single lambda expression, only for the sake of resource management, which is now handled via `@AutoCleanup` for the server field definition. As an alternative, in other test frameworks, `server.close()` could be called in a tear-down method running after the test or by using try with resources within the test.