### PR TITLE
Extend the API to list files and directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .flattened-pom.xml
 target
+.idea

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>fake-sftp-server-lambda</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Fake SFTP Server Lambda</name>

--- a/src/main/java/com/github/stefanbirkner/fakesftpserver/lambda/FakeSftpServer.java
+++ b/src/main/java/com/github/stefanbirkner/fakesftpserver/lambda/FakeSftpServer.java
@@ -16,6 +16,7 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.UserPrincipalLookupService;
 import java.nio.file.spi.FileSystemProvider;
 import java.util.*;
+import java.util.stream.Stream;
 
 import static com.github.marschall.memoryfilesystem.MemoryFileSystemBuilder.newLinux;
 import static java.nio.file.FileVisitResult.CONTINUE;
@@ -411,6 +412,21 @@ public class FakeSftpServer {
         verifyWithSftpServerIsNotFinished("check existence of file");
         Path pathAsObject = fileSystem.getPath(path);
         return exists(pathAsObject) && !isDirectory(pathAsObject);
+    }
+
+    /**
+     * List all files and directories in a given directory
+     * @param path the path to the directory
+     * @return a stream with of all files in the directory
+     * @throws IOException see {@link Files#list(Path)}
+     */
+    public Stream<Path> listFilesAndDirectories(
+        String path
+    ) throws IOException
+    {
+        verifyWithSftpServerIsNotFinished("list files");
+        Path pathAsObject = fileSystem.getPath(path);
+        return Files.list(pathAsObject);
     }
 
     /**


### PR DESCRIPTION
To be flexible with the assertions the FakeSftpServer is extended with a method to receive all entries of a given directory.
 